### PR TITLE
added basic csq functionality

### DIFF
--- a/multifm/demod.c
+++ b/multifm/demod.c
@@ -87,7 +87,7 @@ aresult_t demod_thread_process(struct demod_thread *dthr, struct sample_buf *sbu
         dthr->nr_pcm_samples = 0;
 
         TSL_BUG_IF_FAILED(multifm_fm_demod_process(dthr->demod, dthr->filt_samp_buf, dthr->nr_fm_samples,
-                    dthr->out_buf, &dthr->nr_pcm_samples, &nr_processed_bytes));
+                    dthr->out_buf, &dthr->nr_pcm_samples, &nr_processed_bytes, dthr->csq_level_dbfs));
 
         /* x. Write out the resulting PCM samples */
         if (0 > write(dthr->fifo_fd, dthr->out_buf, nr_processed_bytes)) {
@@ -208,10 +208,10 @@ aresult_t _demod_fir_prepare(struct demod_thread *thr, const double *lpf_taps, s
 
     int16_t *coeffs = NULL;
     double f_offs = -2.0 * M_PI * (double)offset_hz / (double)sample_rate;
-#ifdef _DUMP_LPF
-    int64_t power = 0;
-    double dpower = 0.0;
-#endif /* defined(_DUMP_LPF) */
+    #ifdef _DUMP_LPF
+        int64_t power = 0;
+        double dpower = 0.0;
+    #endif /* defined(_DUMP_LPF) */
     size_t base = lpf_nr_taps;
 
     DIAG("Preparing LPF for offset %d Hz", offset_hz);
@@ -225,45 +225,45 @@ aresult_t _demod_fir_prepare(struct demod_thread *thr, const double *lpf_taps, s
         goto done;
     }
 
-#ifdef _DUMP_LPF
-    fprintf(stderr, "lpf_shifted_%d = [\n", offset_hz);
-#endif /* defined(_DUMP_LPF) */
+    #ifdef _DUMP_LPF
+        fprintf(stderr, "lpf_shifted_%d = [\n", offset_hz);
+    #endif /* defined(_DUMP_LPF) */
 
     for (size_t i = 0; i < lpf_nr_taps; i++) {
         /* Calculate the new tap coefficient */
         const double complex lpf_tap = gain * cexp(CMPLX(0, f_offs * (double)i)) * lpf_taps[i];
         const double q15 = 1ll << Q_15_SHIFT;
-#ifdef _DUMP_LPF
-        double ptemp = 0;
-        int64_t samp_power = 0;
-#endif
+        #ifdef _DUMP_LPF
+            double ptemp = 0;
+            int64_t samp_power = 0;
+        #endif
 
         /* Calculate the Q31 coefficient */
         coeffs[       i] = (int16_t)(creal(lpf_tap) * q15);
         coeffs[base + i] = (int16_t)(cimag(lpf_tap) * q15);
 
-#ifdef _DUMP_LPF
-        ptemp = sqrt( (creal(lpf_tap) * creal(lpf_tap)) + (cimag(lpf_tap) * cimag(lpf_tap)) );
-        samp_power = sqrt( ((int64_t)coeffs[i] * (int64_t)coeffs[i]) + ((int64_t)coeffs[base + i] * (int64_t)coeffs[base + i]) );
+        #ifdef _DUMP_LPF
+            ptemp = sqrt( (creal(lpf_tap) * creal(lpf_tap)) + (cimag(lpf_tap) * cimag(lpf_tap)) );
+            samp_power = sqrt( ((int64_t)coeffs[i] * (int64_t)coeffs[i]) + ((int64_t)coeffs[base + i] * (int64_t)coeffs[base + i]) );
 
-        power += samp_power;
-        dpower += ptemp;
+            power += samp_power;
+            dpower += ptemp;
 
-        fprintf(stderr, "    complex(%f, %f), %% (%d, %d)\n", creal(lpf_tap), cimag(lpf_tap), coeffs[i], coeffs[base + i]);
-#endif /* defined(_DUMP_LPF) */
+            fprintf(stderr, "    complex(%f, %f), %% (%d, %d)\n", creal(lpf_tap), cimag(lpf_tap), coeffs[i], coeffs[base + i]);
+        #endif /* defined(_DUMP_LPF) */
     }
-#ifdef _DUMP_LPF
-    fprintf(stderr, "];\n");
-    fprintf(stderr, "%% Total power: %llu (%016llx) (%f)\n", power, power, dpower);
-#endif /* defined(_DUMP_LPF) */
+    #ifdef _DUMP_LPF
+        fprintf(stderr, "];\n");
+        fprintf(stderr, "%% Total power: %llu (%016llx) (%f)\n", power, power, dpower);
+    #endif /* defined(_DUMP_LPF) */
 
     /* Create a Direct Type FIR implementation */
     TSL_BUG_IF_FAILED(direct_fir_init(&thr->fir, lpf_nr_taps, coeffs, &coeffs[base], decimation, true, sample_rate, offset_hz));
 
-done:
-    if (NULL != coeffs) {
-        TFREE(coeffs);
-    }
+    done:
+        if (NULL != coeffs) {
+            TFREE(coeffs);
+        }
 
     return ret;
 }
@@ -272,7 +272,8 @@ aresult_t demod_thread_new(struct demod_thread **pthr, unsigned core_id,
         int32_t offset_hz, uint32_t samp_hz, const char *out_fifo, int decimation_factor,
         const double *lpf_taps, size_t lpf_nr_taps,
         const char *fir_debug_output,
-        double channel_gain)
+        double channel_gain,
+        int csq_level_dbfs)
 {
     aresult_t ret = A_OK;
 
@@ -292,6 +293,9 @@ aresult_t demod_thread_new(struct demod_thread **pthr, unsigned core_id,
 
     thr->fifo_fd = -1;
     thr->debug_signal_fd = -1;
+
+    // Pass in the CSQ variable
+    thr->csq_level_dbfs = csq_level_dbfs;
 
     /* Initialize the work queue */
     if (FAILED(ret = work_queue_new(&thr->wq, 128))) {

--- a/multifm/demod.h
+++ b/multifm/demod.h
@@ -99,6 +99,11 @@ struct demod_thread {
      * Output demodulated sample buffer
      */
     int16_t out_buf[LPF_OUTPUT_LEN];
+
+    /**
+     * CSQ level in dBFS (0 = open squelch)
+     */
+    int8_t csq_level_dbfs;
 };
 
 aresult_t demod_thread_delete(struct demod_thread **pthr);
@@ -113,5 +118,6 @@ aresult_t demod_thread_new(struct demod_thread **pthr, unsigned core_id,
         int32_t offset_hz, uint32_t samp_hz, const char *out_fifo, int decimation_factor,
         const double *lpf_taps, size_t lpf_nr_taps,
         const char *fir_debug_output,
-        double channel_gain);
+        double channel_gain,
+        int csq_level_dbfs);
 

--- a/multifm/fm_demod.c
+++ b/multifm/fm_demod.c
@@ -1,6 +1,7 @@
 #include <multifm/fm_demod.h>
 #include <multifm/demod_base.h>
 #include <multifm/fast_atan2f.h>
+#include <multifm/multifm.h>
 
 #include <filter/filter.h>
 
@@ -34,7 +35,7 @@ aresult_t multifm_fm_demod_init(struct demod_base **pdemod)
 }
 
 aresult_t multifm_fm_demod_process(struct demod_base *demod, int16_t *in_samples, size_t nr_in_samples,
-        int16_t *out_samples, size_t *pnr_out_samples, size_t *pnr_out_bytes)
+        int16_t *out_samples, size_t *pnr_out_samples, size_t *pnr_out_bytes, int csq_level_dbfs)
 {
     aresult_t ret = A_OK;
 
@@ -50,29 +51,55 @@ aresult_t multifm_fm_demod_process(struct demod_base *demod, int16_t *in_samples
 
     dfm = BL_CONTAINER_OF(demod, struct multifm_fm_demod, demod);
 
+    // Calculate average power of samples
+    float sum_smp_rms = 0;
     for (size_t i = 0; i < nr_in_samples; i++) {
-        /* Get the complex conjugate of the prior sample, negating the phase term */
-        int32_t b_re =  dfm->last_fm_re,
-                b_im = -dfm->last_fm_im,
-                a_re =  in_samples[2 * i    ],
+        // Calculate RMS of I & Q samples
+        int32_t re_smp = in_samples[2 * i];
+        int32_t im_smp = in_samples[2 * i + 1];
+        float smp_rms = sqrt( ( pow(re_smp,2) + pow(im_smp,2) ) / 2.0 );
+        sum_smp_rms += smp_rms;
+    }
+    float avg_smp_rms = sum_smp_rms / (float)nr_in_samples;
+    // Convert to dBm
+    float avg_smp_vrms = (avg_smp_rms + SMP_OFFSET) / SMP_SCALE;
+    float avg_smp_wrms = pow(avg_smp_vrms,2)/50.0;
+    float avg_smp_dBFS = 10*log10(avg_smp_wrms);
+    // Debug print
+    //MFM_MSG(SEV_INFO, "CSQ_DEBUG", "Average sample pwr: %.3f, %.3f dBFS, calc. from %d samples", avg_smp_rms, avg_smp_dBFS, (int)nr_in_samples);
+
+    // Demod the samples if we're above the threshold, silence if not
+    for (size_t i = 0; i < nr_in_samples; i++) {
+        // Get next samples
+        int32_t a_re =  in_samples[2 * i    ],
                 a_im =  in_samples[2 * i + 1];
-        int32_t s_re = 0,
-                s_im = 0;
+        // Check squelch and demod if above threshold or if we're in open squelch
+        if ((avg_smp_dBFS >= csq_level_dbfs) || csq_level_dbfs == 0) {
+            /* Get the complex conjugate of the prior sample, negating the phase term */
+            int32_t b_re =  dfm->last_fm_re,
+                    b_im = -dfm->last_fm_im;
+            int32_t s_re = 0,
+                    s_im = 0;
 
-        /* Calculate the phase difference */
-        s_re = a_re * b_re - a_im * b_im;
-        s_im = a_re * b_im + a_im * b_re;
+            /* Calculate the phase difference */
+            s_re = a_re * b_re - a_im * b_im;
+            s_im = a_re * b_im + a_im * b_re;
 
-        /* Convert from cartesian coordinates to a phase angle */
-        /* TODO: This needs to be made full-integer */
-        float phi = fast_atan2f((float)s_im, (float)s_re);
+            /* Convert from cartesian coordinates to a phase angle */
+            /* TODO: This needs to be made full-integer */
+            float phi = fast_atan2f((float)s_im, (float)s_re);
 
-        /* Scale by pi (since atan2 returns an angle in (-pi,pi]), convert back to Q.15 */
-        float phi_scaled = (phi/M_PI) * to_q15;
-        out_samples[nr_out_samples] = (int16_t)phi_scaled;
-
+            /* Scale by pi (since atan2 returns an angle in (-pi,pi]), convert back to Q.15 */
+            float phi_scaled = (phi/M_PI) * to_q15;
+            out_samples[nr_out_samples] = (int16_t)phi_scaled;
+        }
+        // Output silence if below threshold
+        else {
+            out_samples[nr_out_samples] = (int16_t)0;
+            
+        }
+        // Do this regardless
         nr_out_samples++;
-
         /* Store the last sample processed */
         dfm->last_fm_re = a_re;
         dfm->last_fm_im = a_im;

--- a/multifm/fm_demod.c
+++ b/multifm/fm_demod.c
@@ -66,7 +66,7 @@ aresult_t multifm_fm_demod_process(struct demod_base *demod, int16_t *in_samples
     float avg_smp_wrms = pow(avg_smp_vrms,2)/50;
     float avg_smp_dBFS = 10*log10(avg_smp_wrms);
     // Debug print
-    MFM_MSG(SEV_INFO, "CSQ_DEBUG", "Average sample pwr: %.2f, %.2f dBFS, calc. from %d samples", avg_smp_rms, avg_smp_dBFS, (int)nr_in_samples);
+    //MFM_MSG(SEV_INFO, "CSQ_DEBUG", "Average sample pwr: %.2f, %.2f dBFS, calc. from %d samples", avg_smp_rms, avg_smp_dBFS, (int)nr_in_samples);
 
     // Demod the samples if we're above the threshold, silence if not
     for (size_t i = 0; i < nr_in_samples; i++) {

--- a/multifm/fm_demod.c
+++ b/multifm/fm_demod.c
@@ -52,21 +52,21 @@ aresult_t multifm_fm_demod_process(struct demod_base *demod, int16_t *in_samples
     dfm = BL_CONTAINER_OF(demod, struct multifm_fm_demod, demod);
 
     // Calculate average power of samples
-    float sum_smp_rms = 0;
+    uint32_t sum_smp_rms = 0;
     for (size_t i = 0; i < nr_in_samples; i++) {
         // Calculate RMS of I & Q samples
         int32_t re_smp = in_samples[2 * i];
         int32_t im_smp = in_samples[2 * i + 1];
-        float smp_rms = sqrt( ( pow(re_smp,2) + pow(im_smp,2) ) / 2.0 );
+        int32_t smp_rms = sqrt( ( pow(re_smp,2) + pow(im_smp,2) ) / 2.0 );
         sum_smp_rms += smp_rms;
     }
-    float avg_smp_rms = sum_smp_rms / (float)nr_in_samples;
+    float avg_smp_rms = (float)sum_smp_rms / (float)nr_in_samples;
     // Convert to dBm
-    float avg_smp_vrms = (avg_smp_rms + SMP_OFFSET) / SMP_SCALE;
-    float avg_smp_wrms = pow(avg_smp_vrms,2)/50.0;
+    float avg_smp_vrms = ((float)avg_smp_rms + SMP_OFFSET) / SMP_SCALE;
+    float avg_smp_wrms = pow(avg_smp_vrms,2)/50;
     float avg_smp_dBFS = 10*log10(avg_smp_wrms);
     // Debug print
-    //MFM_MSG(SEV_INFO, "CSQ_DEBUG", "Average sample pwr: %.3f, %.3f dBFS, calc. from %d samples", avg_smp_rms, avg_smp_dBFS, (int)nr_in_samples);
+    MFM_MSG(SEV_INFO, "CSQ_DEBUG", "Average sample pwr: %.2f, %.2f dBFS, calc. from %d samples", avg_smp_rms, avg_smp_dBFS, (int)nr_in_samples);
 
     // Demod the samples if we're above the threshold, silence if not
     for (size_t i = 0; i < nr_in_samples; i++) {

--- a/multifm/fm_demod.h
+++ b/multifm/fm_demod.h
@@ -9,7 +9,7 @@
  *  and dbFS is a pretty relative measurement to begin with.
  */
 #define SMP_SCALE   2300.0
-#define SMP_OFFSET  -4.1
+#define SMP_OFFSET  -3.6
 
 struct demod_base;
 

--- a/multifm/fm_demod.h
+++ b/multifm/fm_demod.h
@@ -2,6 +2,15 @@
 
 #include <tsl/result.h>
 
+/**
+ *  divisor to convert raw sample power to microwatts for dBm calculation,
+ *  found experimentally using a known channel power measured via SDRSharp.
+ *  There's probably a much better way to calculated dBFS but this works "well enough," 
+ *  and dbFS is a pretty relative measurement to begin with.
+ */
+#define SMP_SCALE   2300.0
+#define SMP_OFFSET  -4.1
+
 struct demod_base;
 
 /**
@@ -26,7 +35,7 @@ aresult_t multifm_fm_demod_init(struct demod_base **pdemod);
  * out to the real-valued PCM buffer.
  */
 aresult_t multifm_fm_demod_process(struct demod_base *demod, int16_t *in_samples, size_t nr_in_samples,
-        int16_t *out_samples, size_t *pnr_out_samples, size_t *pnr_out_bytes);
+        int16_t *out_samples, size_t *pnr_out_samples, size_t *pnr_out_bytes, int csq_level_dbfs);
 
 /**
  * Cleanup the resources used by the FM demodulator

--- a/multifm/receiver.c
+++ b/multifm/receiver.c
@@ -130,16 +130,19 @@ aresult_t receiver_init(struct receiver *rx, struct config *cfg,
     rx->cleanup_func = cleanup_func;
     rx->thread_func = rx_func;
 
+    // Get sample buffer from config or default to 64
     if (FAILED(ret = config_get_integer(cfg, &nr_samp_bufs, "nrSampBufs"))) {
         MFM_MSG(SEV_INFO, "DEFAULT-SAMP-BUFS", "Setting sample buffer count to 64");
         nr_samp_bufs = 64;
     }
 
+    // Get sample rate
     if (FAILED(ret = config_get_integer(cfg, &sample_rate, "sampleRateHz"))) {
         MFM_MSG(SEV_INFO, "NO-SAMPLE-RATE", "Need to specify a sample rate, in Hertz.");
         goto done;
     }
 
+    // Get center freq
     if (FAILED(ret = config_get_integer(cfg, &center_freq, "centerFreqHz"))) {
         MFM_MSG(SEV_INFO, "NO-CENTER-FREQ", "You forgot to specify a center frequency, in Hz.");
         goto done;
@@ -200,21 +203,39 @@ aresult_t receiver_init(struct receiver *rx, struct config *cfg,
         double channel_gain = 1.0,
                channel_gain_db = 0.0;
 
+        // Var for optional CSQ mode
+        int csq_level_dbfs = 0;
+
+        // FIFO location
         if (FAILED(ret = config_get_string(&channel, &fifo_name, "outFifo"))) {
             MFM_MSG(SEV_ERROR, "MISSING-FIFO-ID", "Missing output FIFO filename, aborting.");
             goto done;
         }
 
+        // Channel frequency
         if (FAILED(ret = config_get_integer(&channel, &nb_center_freq, "chanCenterFreq"))) {
             MFM_MSG(SEV_ERROR, "MISSING-CENTER-FREQ", "Missing output channel center frequency.");
             goto done;
         }
 
+        // Optional CSQ parameter
+        if (FAILED(ret = config_get_integer(&channel, &csq_level_dbfs, "csqLeveldBFS"))) {
+            MFM_MSG(SEV_INFO, "MISSING-SQUELCH", "No squelch specified, channel will be open squelch.");
+        } else {
+            if (csq_level_dbfs == 0) {
+                MFM_MSG(SEV_INFO, "NO-SQUELCH", "Squelch of 0 specified, channel will be open squelch.");
+            } else {
+                MFM_MSG(SEV_INFO, "CARRIER-SQUELCH", "Channel carrier squelch set to %d", csq_level_dbfs);
+            }
+        }
+
+        // Optional debug
         if (!FAILED(ret = config_get_string(&channel, &signal_debug, "signalDebugFile"))) {
             MFM_MSG(SEV_INFO, "WRITING-SIGNAL-DEBUG", "The channel at frequency %d will have raw I/Q written to '%s'",
                     nb_center_freq, signal_debug);
         }
 
+        // Optional channel gain
         if (!FAILED(ret = config_get_float(&channel, &channel_gain_db, "dBGain"))) {
             /* Convert the gain to linear units */
             channel_gain = pow(10.0, channel_gain_db/10.0);
@@ -227,7 +248,8 @@ aresult_t receiver_init(struct receiver *rx, struct config *cfg,
         if (FAILED(ret = demod_thread_new(&dmt, -1, (int32_t)nb_center_freq - center_freq,
                         sample_rate, fifo_name, decimation_factor, lpf_taps, lpf_nr_taps,
                         signal_debug,
-                        channel_gain)))
+                        channel_gain,
+                        csq_level_dbfs)))
         {
             MFM_MSG(SEV_ERROR, "FAILED-DEMOD-THREAD", "Failed to create demodulator thread, aborting.");
             goto done;


### PR DESCRIPTION
added an optional parameter to the config json file

per channel, you can specify a "csqLeveldBFS" parameter which is the squelch threshold in dBFS (the same unit SDR sharp uses). A value of 0, or the parameter missing entirely, will result in open squelch.

See below:

```json
"channels" : [
    {
      "outFifo" : "test.out",
      "chanCenterFreq" : 100000000,
      "csqLeveldBFS" : -60
    }
  ]
```

There's probably a much better way to calculate dBFS from I/Q sample RMS values, but I just did it experimentally by taking two known points measured in SDRSharp (the noise floor and a constant FM signal) and working backwards from the raw RMS sample values to get the proper scaling factors.

Still todo is adding in some basic predelay/hysteresis to eliminate the leading squelch break. 