### PR TITLE
Add rtlsdr selection option

### DIFF
--- a/multifm/rtl_sdr_if.c
+++ b/multifm/rtl_sdr_if.c
@@ -350,6 +350,7 @@ aresult_t __rtl_sdr_device_search(const int user_idx, const char *user_serial, i
     device_count = rtlsdr_get_device_count();
 
     if (device_count < 1) {
+	MFM_MSG(SEV_ERROR, "DEV-NOT-FOUND", "No RTLSDR devices found.");
         ret = A_E_NOTFOUND;
         goto done;
     }
@@ -480,7 +481,7 @@ aresult_t rtl_sdr_worker_thread_new(
         }
     }
 
-    if (FAILED(ret = __rtl_sdr_device_search(dev_idx, dev_user_serial, &dev_idx, &dev))) {
+    if (FAILED(ret = __rtl_sdr_device_search(dev_user_idx, dev_user_serial, &dev_idx, &dev))) {
         MFM_MSG(SEV_ERROR, "DEV-NOT-FOUND", "Unable to open device.");
         goto done;
     }

--- a/multifm/rtl_sdr_if.c
+++ b/multifm/rtl_sdr_if.c
@@ -398,7 +398,7 @@ aresult_t __rtl_sdr_device_search(const int user_idx, const char *user_serial, i
         if (!rtlsdr_open(out_rtldev, device_iter))
             goto found;
 
-	MFM_MSG(SEV_ERROR, "DEV-NOT-FOUND", "Unable to open RTLSDR with configued deviceIndex '%d'.", user_idx);
+	MFM_MSG(SEV_ERROR, "DEV-NOT-FOUND", "Unable to open RTLSDR with configured deviceIndex '%d'.", user_idx);
         ret = A_E_NOTFOUND;
         goto done;
     }

--- a/multifm/rtl_sdr_if.c
+++ b/multifm/rtl_sdr_if.c
@@ -463,6 +463,7 @@ aresult_t rtl_sdr_worker_thread_new(
     if (FAILED(rret)) {
         if (rret != A_E_NOTFOUND) {
             MFM_MSG(SEV_ERROR, "DEV-DEVIDX-INVAL", "Value for 'deviceIndex' is invalid.");
+            ret = rret;
             goto done;
         }
     }
@@ -471,6 +472,7 @@ aresult_t rtl_sdr_worker_thread_new(
     if (FAILED(rret)) {
         if (rret != A_E_NOTFOUND) {
             MFM_MSG(SEV_ERROR, "DEV-DEVSER-INVAL", "Value for 'deviceSerial' is invalid.");
+            ret = rret;
             goto done;
         }
     }

--- a/multifm/rtl_sdr_if.c
+++ b/multifm/rtl_sdr_if.c
@@ -385,7 +385,9 @@ aresult_t __rtl_sdr_device_search(const int user_idx, const char *user_serial, i
                     && !rtlsdr_open(out_rtldev, device_iter))
                 goto found;
         }
-        ret = A_E_NOTFOUND;
+
+        MFM_MSG(SEV_ERROR, "DEV-NOT-FOUND", "Unable to open any RTLSDR matching or containing configured deviceSerial '%s'.", user_serial);
+	ret = A_E_NOTFOUND;
         goto done;
     }
 
@@ -395,6 +397,7 @@ aresult_t __rtl_sdr_device_search(const int user_idx, const char *user_serial, i
         if (!rtlsdr_open(out_rtldev, device_iter))
             goto found;
 
+	MFM_MSG(SEV_ERROR, "DEV-NOT-FOUND", "Unable to open RTLSDR with configued deviceIndex '%d'.", user_idx);
         ret = A_E_NOTFOUND;
         goto done;
     }
@@ -404,8 +407,8 @@ aresult_t __rtl_sdr_device_search(const int user_idx, const char *user_serial, i
         if (!rtlsdr_open(out_rtldev, device_iter)) 
             goto found;
     }
-    ret = A_E_NOTFOUND;
 
+    ret = A_E_NOTFOUND;
 found:
     *out_idx = device_iter;
 


### PR DESCRIPTION
The RTLSDR device index isn't reliable for configurations with multiple RTL SDR's. RTL-SDR's can be programmed with a user supplied serial number. This patch allows configuring the RTLSDR by device serial number matching instead of device index. This should solve #22 as well.