### PR TITLE
Add channel center frequency to decoder JSON output.

### DIFF
--- a/decoder/decoder.c
+++ b/decoder/decoder.c
@@ -182,7 +182,8 @@ aresult_t _on_flex_alnum_msg(
         bool maildrop,
         uint8_t seq_num,
         const char *message_bytes,
-        size_t message_len)
+        size_t message_len,
+	uint32_t freq_hz)
 {
     /* TODO: this sucks, should move it closer to the capture clock */
     time_t now = time(NULL);
@@ -190,10 +191,10 @@ aresult_t _on_flex_alnum_msg(
 
     fprintf(out_file, "{\"proto\":\"flex\",\"type\":\"alphanumeric\",\"timestamp\":\"%04i-%02i-%02i %02i:%02i:%02i UTC\","
             "\"baud\":%i,\"syncLevel\":%i,\"frameNo\":%u,\"cycleNo\":%u,\"phaseNo\":\"%c\",\"capCode\":%"PRIu64",\"fragment\":%s,"
-            "\"maildrop\":%s,\"fragSeq\":%u,\"message\":\"",
+            "\"maildrop\":%s,\"fragSeq\":%u,\"freq_hz\":%u,\"message\":\"",
             gmt->tm_year + 1900, gmt->tm_mon + 1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
             baud, 0, frame_no, cycle_no, phase_id[phase], cap_code,
-            fragmented ? "true" : "false", maildrop ? "true" : "false", seq_num);
+            fragmented ? "true" : "false", maildrop ? "true" : "false", seq_num, freq_hz);
 
     for (size_t i = 0; i < message_len; i++) {
         _decoder_put_alnum_char(out_file, message_bytes[i]);
@@ -214,16 +215,18 @@ aresult_t _on_flex_num_msg(
         uint8_t frame_no,
         uint64_t cap_code,
         const char *message_bytes,
-        size_t message_len)
+        size_t message_len,
+	uint32_t freq_hz)
 {
     /* TODO: this sucks, should move it closer to the capture clock */
     time_t now = time(NULL);
     struct tm *gmt = gmtime(&now);
 
     fprintf(out_file, "{\"proto\":\"flex\",\"type\":\"numeric\",\"timestamp\":\"%04i-%02i-%02i %02i:%02i:%02i UTC\","
-            "\"baud\":%i,\"syncLevel\":%i,\"frameNo\":%u,\"cycleNo\":%u,\"phaseNo\":\"%c\",\"capCode\":%"PRIu64",\"message\":\"",
+            "\"baud\":%i,\"syncLevel\":%i,\"frameNo\":%u,\"cycleNo\":%u,\"phaseNo\":\"%c\",\"capCode\":%"PRIu64","
+	    "\"freq_hz\":%u,\"message\":\"",
             gmt->tm_year + 1900, gmt->tm_mon + 1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
-            baud, 0, frame_no, cycle_no, phase_id[phase], cap_code);
+            baud, 0, frame_no, cycle_no, phase_id[phase], cap_code, freq_hz);
 
     for (size_t i = 0; i < message_len; i++) {
         _decoder_put_alnum_char(out_file, message_bytes[i]);
@@ -244,7 +247,8 @@ aresult_t _on_flex_siv_msg(
         uint8_t frame_no,
         uint64_t cap_code,
         uint8_t siv_msg_type,
-        uint32_t data)
+        uint32_t data,
+	uint32_t freq_hz)
 {
     /* TODO: this sucks, should move it closer to the capture clock */
     time_t now = time(NULL);
@@ -253,9 +257,9 @@ aresult_t _on_flex_siv_msg(
     switch (siv_msg_type) {
     case PAGER_FLEX_SIV_TEMP_ADDRESS_ACTIVATION:
         fprintf(out_file, "{\"proto\":\"flex\",\"type\":\"tempAddrActivation\",\"timestamp\":\"%04i-%02i-%02i %02i:%02i:%02i UTC\","
-                "\"baud\":%i,\"syncLevel\":%i,\"frameNo\":%u,\"cycleNo\":%u,\"phaseNo\":\"%c\",\"capCode\":%"PRIu64",\"startFrameNo\":%u,\"tempAddressId\":%u}\n",
+                "\"baud\":%i,\"syncLevel\":%i,\"frameNo\":%u,\"cycleNo\":%u,\"phaseNo\":\"%c\",\"capCode\":%"PRIu64",\"startFrameNo\":%u,\"tempAddressId\":%u,\"freq_hz\":%u}\n",
                 gmt->tm_year + 1900, gmt->tm_mon + 1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
-                baud, 0, frame_no, cycle_no, phase_id[phase], cap_code, data & 0x7f, (data >> 7) & 0xf);
+                baud, 0, frame_no, cycle_no, phase_id[phase], cap_code, data & 0x7f, (data >> 7) & 0xf, freq_hz);
         break;
     }
     return A_OK;
@@ -268,16 +272,17 @@ aresult_t _on_pocsag_alnum_msg(
         uint32_t capcode,
         const char *data,
         size_t data_len,
-        uint8_t function)
+        uint8_t function,
+	uint32_t freq_hz)
 {
     /* TODO: this sucks, should move it closer to the capture clock */
     time_t now = time(NULL);
     struct tm *gmt = gmtime(&now);
 
     fprintf(out_file, "{\"proto\":\"pocsag\",\"type\":\"alphanumeric\",\"timestamp\":\"%04i-%02i-%02i %02i:%02i:%02i UTC\","
-            "\"baud\":%i,\"capCode\":%u,\"function\":%u,\"message\":\"",
+            "\"baud\":%i,\"capCode\":%u,\"function\":%u,\"freq_hz\":%u,\"message\":\"",
             gmt->tm_year + 1900, gmt->tm_mon + 1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
-            baud_rate, capcode, (unsigned)function);
+            baud_rate, capcode, (unsigned)function, freq_hz);
 
     for (size_t i = 0; i < data_len; i++) {
         _decoder_put_alnum_char(out_file, data[i]);
@@ -296,16 +301,17 @@ aresult_t _on_pocsag_num_msg(
         uint32_t capcode,
         const char *data,
         size_t data_len,
-        uint8_t function)
+        uint8_t function,
+	uint32_t freq_hz)
 {
     /* TODO: this sucks, should move it closer to the capture clock */
     time_t now = time(NULL);
     struct tm *gmt = gmtime(&now);
 
     fprintf(out_file, "{\"proto\":\"pocsag\",\"type\":\"numeric\",\"timestamp\":\"%04i-%02i-%02i %02i:%02i:%02i UTC\","
-            "\"baud\":%i,\"capCode\":%u,\"function\":%u,\"message\":\"",
+            "\"baud\":%i,\"capCode\":%u,\"function\":%u,\"freq_hz\":%u,\"message\":\"",
             gmt->tm_year + 1900, gmt->tm_mon + 1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
-            baud_rate, capcode, (unsigned)function);
+            baud_rate, capcode, (unsigned)function, freq_hz);
 
     for (size_t i = 0; i < data_len; i++) {
         _decoder_put_alnum_char(out_file, data[i]);

--- a/pager/pager_flex.c
+++ b/pager/pager_flex.c
@@ -674,7 +674,7 @@ aresult_t _pager_flex_decode_alphanumeric(struct pager_flex *flex, uint8_t phase
     }
 
     ret = flex->on_alnum_msg(flex, coding->baud, phase, flex->cycle_id, flex->frame_id, capcode,
-            fragment, maildrop, seq_num, flex->msg_buf, flex->msg_len);
+            fragment, maildrop, seq_num, flex->msg_buf, flex->msg_len, flex->freq_hz);
 
 done:
     return ret;
@@ -817,7 +817,7 @@ aresult_t _pager_flex_decode_numeric(struct pager_flex *flex, uint8_t phase, uin
     } while (0 != nr_bits);
 
     ret = flex->on_num_msg(flex, coding->baud, phase, flex->cycle_id, flex->frame_id,
-            capcode, flex->msg_buf, flex->msg_len);
+            capcode, flex->msg_buf, flex->msg_len, flex->freq_hz);
 
 done:
     return ret;
@@ -862,7 +862,7 @@ aresult_t _pager_flex_decode_tone(struct pager_flex *flex, uint8_t phase, uint64
         }
 
         /* Deliver the message as a normal alphanumeric message */
-        ret = flex->on_num_msg(flex, coding->baud, phase, flex->cycle_id, flex->frame_id, capcode, flex->msg_buf, flex->msg_len);
+        ret = flex->on_num_msg(flex, coding->baud, phase, flex->cycle_id, flex->frame_id, capcode, flex->msg_buf, flex->msg_len, flex->freq_hz);
         break;
     case PAGER_FLEX_SHORT_TYPE_8_SOURCES:
         PAG_MSG(SEV_INFO, "TONE", "%02u/%03u/%c [ %9"PRIu64"] Sourced Tone: [%08x, %08x]", flex->cycle_id, flex->frame_id, phase + 'A', capcode, first_word, second_word);
@@ -924,7 +924,7 @@ aresult_t _pager_flex_decode_short_instruction_vec(struct pager_flex *flex, uint
 
     if (NULL != flex->on_siv_msg) {
         flex->on_siv_msg(flex, coding->baud, phase, flex->cycle_id, flex->frame_id, capcode,
-                siv_type, siv_data);
+                siv_type, siv_data, flex->freq_hz);
     }
 
 

--- a/pager/pager_flex.h
+++ b/pager/pager_flex.h
@@ -24,7 +24,8 @@ typedef aresult_t (*pager_flex_on_alnum_msg_func_t)(
         bool maildrop,
         uint8_t seq_num,
         const char *message_bytes,
-        size_t message_len);
+        size_t message_len,
+	uint32_t freq_hz);
 
 /**
  * Callback type. This is registered with each pager_flex, and is called whenever there is a long numeric page to process.
@@ -40,7 +41,8 @@ typedef aresult_t (*pager_flex_on_num_msg_func_t)(
         uint8_t frame_no,
         uint64_t cap_code,
         const char *message_bytes,
-        size_t message_len);
+        size_t message_len,
+	uint32_t freq_hz);
 
 /**
  * Special Instruction Vector (SIV) types
@@ -80,7 +82,8 @@ typedef aresult_t (*pager_flex_on_siv_msg_func_t)(
         uint8_t frame_no,
         uint64_t cap_code,
         uint8_t siv_msg_type,
-        uint32_t data);
+        uint32_t data,
+	uint32_t freq_hz);
 
 /**
  * Create a new FLEX pager handler.

--- a/pager/pager_pocsag.c
+++ b/pager/pager_pocsag.c
@@ -183,6 +183,7 @@ aresult_t pager_pocsag_new(struct pager_pocsag **ppocsag, uint32_t freq_hz,
     _pager_pocsag_message_decode_reset(&pocsag->decoder);
 
     pocsag->skip_bch = skip_bch_decode;
+    pocsag->freq_hz = freq_hz;
 
     *ppocsag = pocsag;
 
@@ -278,7 +279,7 @@ aresult_t _pager_pocsag_message_decode_deliver(struct pager_pocsag *pocsag, stru
 #endif /* defined(_PAGER_POCSAG_DEBUG) */
             decode->message_alpha[decode->next_byte_alpha] = '\0';
             TSL_BUG_IF_FAILED(pocsag->on_alpha(pocsag, pocsag->baud_rate, decode->cap_code,
-                        decode->message_alpha, decode->next_byte_alpha, decode->function));
+                        decode->message_alpha, decode->next_byte_alpha, decode->function, pocsag->freq_hz));
         } else {
 #ifdef _PAGER_POCSAG_DEBUG
             decode->message_alpha[decode->next_byte_alpha] = '\0';
@@ -287,7 +288,7 @@ aresult_t _pager_pocsag_message_decode_deliver(struct pager_pocsag *pocsag, stru
 #endif /* defined(_PAGER_POCSAG_DEBUG) */
             decode->message_numeric[decode->next_byte_numeric] = '\0';
             TSL_BUG_IF_FAILED(pocsag->on_numeric(pocsag, pocsag->baud_rate, decode->cap_code,
-                        decode->message_numeric, decode->next_byte_numeric, decode->function));
+                        decode->message_numeric, decode->next_byte_numeric, decode->function, pocsag->freq_hz));
         }
     }
     _pager_pocsag_message_decode_reset(decode);

--- a/pager/pager_pocsag.h
+++ b/pager/pager_pocsag.h
@@ -11,7 +11,8 @@ typedef aresult_t (*pager_pocsag_on_numeric_msg_func_t)(
         uint32_t capcode,
         const char *data,
         size_t data_len,
-        uint8_t function);
+        uint8_t function,
+	uint32_t freq_hz);
 
 typedef aresult_t (*pager_pocsag_on_alpha_msg_func_t)(
         struct pager_pocsag *pocsag,
@@ -19,7 +20,8 @@ typedef aresult_t (*pager_pocsag_on_alpha_msg_func_t)(
         uint32_t capcode,
         const char *data,
         size_t data_len,
-        uint8_t function);
+        uint8_t function,
+	uint32_t freq_hz);
 
 /**
  * Create a new POCSAG decoder.

--- a/pager/pager_pocsag_priv.h
+++ b/pager/pager_pocsag_priv.h
@@ -284,5 +284,10 @@ struct pager_pocsag {
      * Current state of the wire protocol handling
      */
     enum pager_pocsag_state cur_state;
+
+    /**
+     * Frequency, in Hertz, of the center of this pager channel
+     */
+    uint32_t freq_hz;
 };
 


### PR DESCRIPTION
Added the `freq_hz` field to the POCSAG state structure and updated the decoder JSON output functions to emit the channel center frequency as `"freq_hz"`. 